### PR TITLE
server.address() is a object

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -328,7 +328,7 @@ if (cluster.isMaster) {
 
   server.listen(process.env.PORT || 4000, () => {
     log.level = process.env.LOG_LEVEL || 'verbose'
-    log.info(`Starting streaming API server worker on ${server.address()}`)
+    log.info(`Starting streaming API server worker on ${server.address().address}:${server.address().port}`)
   })
 
   process.on('SIGINT', exit)


### PR DESCRIPTION
Untested, but should be something like

https://nodejs.org/api/cluster.html#cluster_event_listening_1

Current docker logs is something like
```
streaming_1  | info Starting streaming API server worker on [object Object]
```

